### PR TITLE
Enhance UI security and reorganize layout of info boxes

### DIFF
--- a/src/app/wallet/create/page.tsx
+++ b/src/app/wallet/create/page.tsx
@@ -289,21 +289,21 @@ export default function CreateWalletPage() {
                   </div>
                 ) : (
                   <div>
-                    <div className="mb-4 p-3 rounded-lg border border-amber-200 dark:border-amber-900 bg-amber-50 dark:bg-amber-950/20 flex items-start gap-2">
-                      <TriangleAlert className="w-4 h-4 mt-0.5 text-amber-600 dark:text-amber-400 shrink-0" />
-                      <p className="text-sm text-amber-900 dark:text-amber-200">
-                        <strong className="font-semibold">{t('create.orderMatters.title')}</strong>{' '}
-                        {t('create.orderMatters.body')}
-                      </p>
-                    </div>
-                    <MnemonicDisplay words={words} revealed />
-                    <div className="mt-6 p-4 bg-blue-50 dark:bg-blue-950/20 rounded-lg border border-blue-200 dark:border-blue-900">
+                    <div className="mb-4 p-3 bg-blue-50 dark:bg-blue-950/20 rounded-lg border border-blue-200 dark:border-blue-900">
                       <div className="flex items-start gap-2">
                         <Lightbulb className="w-4 h-4 mt-0.5 text-blue-700 dark:text-blue-300 shrink-0" />
                         <p className="text-sm text-blue-900 dark:text-blue-200">
                           {t('create.tip')}
                         </p>
                       </div>
+                    </div>
+                    <MnemonicDisplay words={words} revealed />
+                    <div className="mt-6 p-4 rounded-lg border border-amber-200 dark:border-amber-900 bg-amber-50 dark:bg-amber-950/20 flex items-start gap-2">
+                      <TriangleAlert className="w-4 h-4 mt-0.5 text-amber-600 dark:text-amber-400 shrink-0" />
+                      <p className="text-sm text-amber-900 dark:text-amber-200">
+                        <strong className="font-semibold">{t('create.orderMatters.title')}</strong>{' '}
+                        {t('create.orderMatters.body')}
+                      </p>
                     </div>
                   </div>
                 )}

--- a/src/components/wallet/mnemonic-display.tsx
+++ b/src/components/wallet/mnemonic-display.tsx
@@ -15,7 +15,7 @@ export function MnemonicDisplay({ words, revealed = true }: MnemonicDisplayProps
       {words.map((word, index) => (
         <div
           key={index}
-          className="flex items-center gap-3 p-4 rounded-lg bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700"
+          className="select-none flex items-center gap-3 p-4 rounded-lg bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700"
         >
           <span className="text-sm font-medium text-gray-500 dark:text-gray-400 w-6">
             {index + 1}.


### PR DESCRIPTION
Swap the 'Tip' and 'Warning' info boxes on the Create screen: [ENG-366](https://b4os.atlassian.net/browse/ENG-366?atlOrigin=eyJpIjoiYjRiZDBlZTRkOGU4NGY1OTkwM2RiMGFlOWFiN2ExNTciLCJwIjoiaiJ9).
Prevent selection over the seed phrase: [ENG-367](https://b4os.atlassian.net/browse/ENG-367?atlOrigin=eyJpIjoiMzczNTMxMmU4ZTdkNDZmNmE3YWViYzczNDY0ZGU3NTgiLCJwIjoiaiJ9).

[ENG-366]: https://b4os.atlassian.net/browse/ENG-366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-367]: https://b4os.atlassian.net/browse/ENG-367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

**Before:**

<img width="682" height="834" alt="Screenshot 2026-07-13 at 4 34 25 PM" src="https://github.com/user-attachments/assets/27e27c9b-820c-4763-9b4c-884399b0a0b6" />

---

**After:**

<img width="679" height="832" alt="Screenshot 2026-07-13 at 4 34 51 PM" src="https://github.com/user-attachments/assets/0422f4d1-e902-4623-b840-7b6f5bf60168" />

**Goal:** Disable text selection over the seed phrase to avoid unauthorized copying and leaking of the backup phrase and reorder info boxes to establish a clearer visual hierarchy based on importance.
