### PR TITLE
add language selection option

### DIFF
--- a/src/app/wallet/settings/page.tsx
+++ b/src/app/wallet/settings/page.tsx
@@ -363,7 +363,7 @@ function DriveBackupSection() {
   );
 }
 
-function LanguagePickerSection() {
+export function LanguagePickerSection() {
   const { locale, setLocale } = useLocale();
   return (
     <select

--- a/src/app/wallet/settings/page.tsx
+++ b/src/app/wallet/settings/page.tsx
@@ -40,11 +40,11 @@ import {
   getLastSyncIso,
   getDriveEmail,
 } from "@/lib/backup/drive-client";
-import { useT, useLocale } from "@/lib/i18n/hook";
-import { LOCALES, LOCALE_LABELS, type Locale } from "@/lib/i18n/types";
+import { useT } from "@/lib/i18n/hook";
 import { useFormatRelativeTime } from "@/lib/wallet/relative-time";
 import type { SdkEvent } from "@/lib/lightning/sdk-events";
 import type { LightningAddressInfo } from "@breeztech/breez-sdk-spark";
+import { LanguagePickerSection } from "@/components/ui/language-picker";
 
 const USERNAME_RE = /^[a-z0-9._-]{1,32}$/;
 
@@ -360,23 +360,6 @@ function DriveBackupSection() {
         </div>
       </Modal>
     </div>
-  );
-}
-
-export function LanguagePickerSection() {
-  const { locale, setLocale } = useLocale();
-  return (
-    <select
-      value={locale}
-      onChange={(e) => setLocale(e.target.value as Locale)}
-      className="w-full px-3 py-2 rounded-lg border-2 border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm"
-    >
-      {LOCALES.map((code) => (
-        <option key={code} value={code}>
-          {LOCALE_LABELS[code]}
-        </option>
-      ))}
-    </select>
   );
 }
 

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Earth, Fingerprint } from "lucide-react";
@@ -11,8 +11,7 @@ import { Modal } from "@/components/ui/modal";
 import { MnemonicDisplay } from "@/components/wallet/mnemonic-display";
 import { APP_NAME } from "@/lib/config";
 import { useWalletStore } from "@/store/wallet-store";
-import { useLocale, useT } from "@/lib/i18n/hook";
-import { LOCALES, LOCALE_LABELS } from "@/lib/i18n/types";
+import { useT } from "@/lib/i18n/hook";
 import {
   isPasskeySupported,
   registerPasskey,
@@ -20,10 +19,13 @@ import {
   seedToMnemonic,
 } from "@/lib/auth/passkey";
 import { mnemonicToWords } from "@/lib/bitcoin/mnemonic";
+import { LanguagePickerSection } from "../wallet/settings/page";
 
 export default function WelcomePage() {
   const t = useT();
   const router = useRouter();
+  const containerRef = useRef<HTMLDivElement>(null);
+
   const hasVault = useWalletStore((s) => s.hasVault);
   const authMode = useWalletStore((s) => s.authMode);
   const isUnlocked = useWalletStore((s) => s.isUnlocked);
@@ -40,7 +42,6 @@ export default function WelcomePage() {
   const [showForget, setShowForget] = useState(false);
   const [forgetConfirm, setForgetConfirm] = useState("");
   const [forgetting, setForgetting] = useState(false);
-  const [showLanguageSelector, setShowLanguageSelector] = useState(false);
 
   const [passkeyAvailable, setPasskeyAvailable] = useState(false);
   const [passkeyMode, setPasskeyMode] = useState(false);
@@ -71,16 +72,6 @@ export default function WelcomePage() {
     // already routes; including it here would race the close with a re-nav.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isBootstrapped, isUnlocked, router]);
-
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        setShowLanguageSelector(false);
-      }
-    }
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [])
 
   const handleCreateWallet = () => {
     setCreatingWallet(true);
@@ -158,6 +149,18 @@ export default function WelcomePage() {
   const showPasskeyUnlock = hasVault && authMode === "passkey";
   const showPasswordUnlock = hasVault && authMode !== "passkey";
 
+  const handleClick = () => {
+  const selectElement = containerRef.current?.querySelector<HTMLSelectElement>("select");
+
+  if (selectElement) {
+    if ("showPicker" in selectElement) {
+      selectElement.showPicker();
+    } else {
+      return null;
+    }
+  }
+};
+
   return (
     <div className="min-h-screen min-w-fit flex flex-col justify-between px-6 py-6 sm:py-10">
       <div className="flex flex-col items-center pb-6 pt-10 sm:flex-1 sm:justify-end sm:pb-20 sm:pt-0">
@@ -171,11 +174,23 @@ export default function WelcomePage() {
           {t("welcome.tagline")}
         </p>
       </div>
-      
-      <button type="button" className="fixed top-6 right-6" onClick={() => setShowLanguageSelector(showLanguageSelector => !showLanguageSelector)}>
-        <Earth />
-      </button>
-      {showLanguageSelector && <LanguageSelectorPopover />}
+
+      <div className="fixed top-6 right-6">
+        <button
+          type="button"
+          onClick={handleClick}
+          className="p-2 z-50 rounded-lg hover:bg-neutral-800/50 transition-colors cursor-pointer text-gray-300 hover:text-white"
+        >
+          <Earth className="w-6 h-6" />
+        </button>
+
+        <div
+          ref={containerRef}
+          className="absolute right-6 top-9 mt-1 opacity-0 pointer-events-none [&>select]:w-auto"
+        >
+          <LanguagePickerSection />
+        </div>
+      </div>
 
       <div className="flex-1 flex flex-col justify-center space-y-4 max-w-md mx-auto w-full px-6">
         {showPasswordUnlock && (
@@ -455,20 +470,4 @@ export default function WelcomePage() {
       </Modal>
     </div>
   );
-}
-
-function LanguageSelectorPopover() {
-  const { locale, setLocale } = useLocale();
-  return (
-    <Card  className="flex flex-col items-start fixed top-12 right-12 pl-4 pr-4 pb-1 pt-1 space-y-1">
-      {LOCALES.map((code) => (
-        <button
-          type="button"
-          className={`cursor-pointer hover:text-blue-600 ${locale === code ? "text-blue-600" : ""}`}
-          key={code}
-          onClick={() => setLocale(code)}>{LOCALE_LABELS[code]}
-        </button>
-      ))}
-    </Card>
-  )
 }

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { Fingerprint } from "lucide-react";
+import { Earth, Fingerprint } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -11,7 +11,8 @@ import { Modal } from "@/components/ui/modal";
 import { MnemonicDisplay } from "@/components/wallet/mnemonic-display";
 import { APP_NAME } from "@/lib/config";
 import { useWalletStore } from "@/store/wallet-store";
-import { useT } from "@/lib/i18n/hook";
+import { useLocale, useT } from "@/lib/i18n/hook";
+import { LOCALES, LOCALE_LABELS } from "@/lib/i18n/types";
 import {
   isPasskeySupported,
   registerPasskey,
@@ -39,6 +40,7 @@ export default function WelcomePage() {
   const [showForget, setShowForget] = useState(false);
   const [forgetConfirm, setForgetConfirm] = useState("");
   const [forgetting, setForgetting] = useState(false);
+  const [showLanguageSelector, setShowLanguageSelector] = useState(false);
 
   const [passkeyAvailable, setPasskeyAvailable] = useState(false);
   const [passkeyMode, setPasskeyMode] = useState(false);
@@ -69,6 +71,16 @@ export default function WelcomePage() {
     // already routes; including it here would race the close with a re-nav.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isBootstrapped, isUnlocked, router]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setShowLanguageSelector(false);
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [])
 
   const handleCreateWallet = () => {
     setCreatingWallet(true);
@@ -148,7 +160,7 @@ export default function WelcomePage() {
 
   return (
     <div className="min-h-screen min-w-fit flex flex-col justify-between px-6 py-6 sm:py-10">
-      <div className="flex flex-col items-center pb-6 sm:flex-1 sm:justify-end sm:pb-20">
+      <div className="flex flex-col items-center pb-6 pt-10 sm:flex-1 sm:justify-end sm:pb-20 sm:pt-0">
         <div className="w-16 h-16 sm:w-24 sm:h-24 bg-gradient-to-br from-blue-400 to-blue-600 rounded-2xl flex items-center justify-center shadow-xl mb-4 sm:mb-8">
           <span className="text-3xl sm:text-5xl font-bold text-white">₿</span>
         </div>
@@ -159,6 +171,11 @@ export default function WelcomePage() {
           {t("welcome.tagline")}
         </p>
       </div>
+      
+      <button type="button" className="fixed top-6 right-6" onClick={() => setShowLanguageSelector(showLanguageSelector => !showLanguageSelector)}>
+        <Earth />
+      </button>
+      {showLanguageSelector && <LanguageSelectorPopover />}
 
       <div className="flex-1 flex flex-col justify-center space-y-4 max-w-md mx-auto w-full px-6">
         {showPasswordUnlock && (
@@ -438,4 +455,20 @@ export default function WelcomePage() {
       </Modal>
     </div>
   );
+}
+
+function LanguageSelectorPopover() {
+  const { locale, setLocale } = useLocale();
+  return (
+    <Card  className="flex flex-col items-start fixed top-12 right-12 pl-4 pr-4 pb-1 pt-1 space-y-1">
+      {LOCALES.map((code) => (
+        <button
+          type="button"
+          className={`cursor-pointer hover:text-blue-600 ${locale === code ? "text-blue-600" : ""}`}
+          key={code}
+          onClick={() => setLocale(code)}>{LOCALE_LABELS[code]}
+        </button>
+      ))}
+    </Card>
+  )
 }

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -19,7 +19,7 @@ import {
   seedToMnemonic,
 } from "@/lib/auth/passkey";
 import { mnemonicToWords } from "@/lib/bitcoin/mnemonic";
-import { LanguagePickerSection } from "../wallet/settings/page";
+import { LanguagePickerSection } from "@/components/ui/language-picker";
 
 export default function WelcomePage() {
   const t = useT();

--- a/src/components/ui/language-picker.tsx
+++ b/src/components/ui/language-picker.tsx
@@ -1,0 +1,19 @@
+import { useLocale } from "@/lib/i18n/hook";
+import { Locale, LOCALE_LABELS, LOCALES } from "@/lib/i18n/types";
+
+export function LanguagePickerSection() {
+  const { locale, setLocale } = useLocale();
+  return (
+    <select
+      value={locale}
+      onChange={(e) => setLocale(e.target.value as Locale)}
+      className="w-full px-3 py-2 rounded-lg border-2 border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm"
+    >
+      {LOCALES.map((code) => (
+        <option key={code} value={code}>
+          {LOCALE_LABELS[code]}
+        </option>
+      ))}
+    </select>
+  );
+}


### PR DESCRIPTION
### 📋 Context
<p>Currently, they are only available in English on the pre-login screen. Given that the wallet will be used in a multicultural and multilingual environment, adding this support would significantly reduce friction and complexity for inexperienced wallet users.</p>

### 🛠️ What has been done
<p>Implement language switcher on welcome page</p>

### 📦 Some considerations
<p>Currently, supporting English and Spanish.</p>
### 📷 Screenshots / GIFs 
<!-- Drag and drop your before/after images here -->
<img width="1800" height="1011" alt="Screenshot 2026-07-21 at 12 52 34 PM" src="https://github.com/user-attachments/assets/48358732-543f-4479-bbd2-8ddf1f33722f" />
<img width="423" height="917" alt="Screenshot 2026-07-21 at 12 53 13 PM" src="https://github.com/user-attachments/assets/68e8ece8-86ff-47be-8550-c756af052582" />

### 🎟️ JIRA Tickets
<!-- Paste the Jira link or ticket ID below. -->
[ENG-368](https://b4os.atlassian.net/browse/ENG-368?atlOrigin=eyJpIjoiMDVjNzc5ZDM4NTE5NGVjZTk2NTU0MzMyNjRhMzUyYjciLCJwIjoiaiJ9)


[ENG-368]: https://b4os.atlassian.net/browse/ENG-368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ