### PR TITLE
feat: add language selection and fiat denomination support

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -234,6 +234,7 @@
     },
     "amount": {
       "label": "Amount (sats)",
+      "fiat": "Amount ({{currency}})",
       "placeholder": "0",
       "helper": "Optional for invoices that already encode an amount"
     },

--- a/messages/es.json
+++ b/messages/es.json
@@ -234,6 +234,7 @@
     },
     "amount": {
       "label": "Monto (sats)",
+      "fiat": "Monto ({{currency}})",
       "placeholder": "0",
       "helper": "Opcional para invoices que ya tienen un monto codificado"
     },

--- a/src/app/wallet/send/page.tsx
+++ b/src/app/wallet/send/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { ArrowLeft, Check, Clipboard, X } from "lucide-react";
+import { ArrowDownUp, ArrowLeft, Check, Clipboard, X } from "lucide-react";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -44,8 +44,11 @@ export default function SendPage() {
   const isUnlocked = useWalletStore((s) => s.isUnlocked);
   const [step, setStep] = useState<SendStep>("input");
   const [destination, setDestination] = useState("");
+  const [rawSats, setRawSats] = useState<number>(0);
   const [amountSatInput, setAmountSatInput] = useState("");
-  const [prepareResult, setPrepareResult] = useState<PrepareResult | null>(null);
+  const [amountFiatInput, setAmountFiatInput] = useState("");
+  const [isSats, setIsSats] = useState(true);
+  const [prepareResult, setPrepareResult] = useState<PrepareResult | null>(null,);
   const [error, setError] = useState("");
 
   const { data: balance } = useBalance(true);
@@ -89,7 +92,7 @@ export default function SendPage() {
         return;
       }
 
-      const amountSat = amountSatInput ? parseInt(amountSatInput, 10) : undefined;
+      const amountSat = rawSats ?? undefined;
 
       let prep: PrepareResult;
       if (parsed.type === "lnurlPay" || parsed.type === "lightningAddress") {
@@ -165,7 +168,64 @@ export default function SendPage() {
     setError("");
     setDestination("");
     setAmountSatInput("");
+    setAmountFiatInput("");
     setPrepareResult(null);
+  };
+
+  useEffect(() => {
+    if (!fiatRate) return;
+
+    if (!rawSats || rawSats <= 0) {
+      setAmountSatInput("");
+      setAmountFiatInput("");
+      return;
+    }
+
+    if (isSats) {
+      setAmountSatInput(rawSats.toString());
+    } else {
+      const calculatedFiat = (rawSats / 100_000_000) * fiatRate;
+      setAmountFiatInput(`$${calculatedFiat.toFixed(2)}`);
+    }
+  }, [isSats]);
+
+  const handleAmountInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!fiatRate) return;
+
+    if (isSats) {
+      const cleanSats = e.target.value.replace(/[^0-9]/g, "");
+      setAmountSatInput(cleanSats);
+
+      const satsNumber = parseInt(cleanSats, 10) || 0;
+      setRawSats(satsNumber);
+    } else {
+      let value = e.target.value.replace(/[^0-9.]/g, "");
+
+      if (value === "") {
+        setAmountFiatInput("");
+        setRawSats(0);
+        return;
+      }
+
+      if (value.startsWith(".")) {
+        value = "0" + value
+      };
+
+      const parts = value.split(".");
+      if (parts.length > 2) {
+        value = `${parts[0]}.${parts.slice(1).join("")}`;
+      }
+
+      if (parts.length >= 2) {
+        value = `${parts[0]}.${parts[1].slice(0, 2)}`;
+      }
+
+      setAmountFiatInput(`$${value}`);
+
+      const numericFiat = parseFloat(value) || 0;
+      const calculatedSats = Math.round((numericFiat / fiatRate) * 100_000_000);
+      setRawSats(calculatedSats);
+    }
   };
 
   if (!isUnlocked) return null;
@@ -214,18 +274,30 @@ export default function SendPage() {
                 error={error || undefined}
                 helperText={t("send.destination.helper")}
               />
-
-              <Input
-                label={t("send.amount.label")}
-                placeholder={t("send.amount.placeholder")}
-                value={amountSatInput}
-                onChange={(e) =>
-                  setAmountSatInput(e.target.value.replace(/[^0-9]/g, ""))
-                }
-                inputMode="numeric"
-                helperText={t("send.amount.helper")}
-              />
-
+              <div className="flex flex-row">
+                <Input
+                  label={
+                    isSats
+                      ? t("send.amount.label")
+                      : t("send.amount.fiat", { currency: fiatCurrency.toLocaleLowerCase() })
+                  }
+                  placeholder={t("send.amount.placeholder")}
+                  value={isSats ? amountSatInput : amountFiatInput}
+                  onChange={(e) => {
+                    handleAmountInput(e);
+                  }}
+                  inputMode="numeric"
+                  helperText={t("send.amount.helper")}
+                />
+                <button
+                  className="px-2 h-16 flex items-end justify-center"
+                  onClick={() => {
+                    setIsSats(!isSats);
+                  }}
+                >
+                  <ArrowDownUp />
+                </button>
+              </div>
               <div className="grid grid-cols-1 gap-3">
                 <Button
                   variant="outline"

--- a/src/app/wallet/send/page.tsx
+++ b/src/app/wallet/send/page.tsx
@@ -183,26 +183,26 @@ export default function SendPage() {
   };
 
   const handleAmountInput = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (!fiatRate) return;
     const rawText = e.target.value;
 
     if (isSats) {
-      const cleanSatsText = rawText.replace(/\D/g, "");
-      setInputValue(cleanSatsText);
-    } else {
-      let cleanFiatText = rawText.replace(/[^0-9.]/g, "");
-      const parts = cleanFiatText.split(".");
-
-      if (parts.length > 2) {
-        cleanFiatText = `${parts[0]}.${parts.slice(1).join("")}`;
-      }
-
-      if (parts.length >= 2) {
-        cleanFiatText = `${parts[0]}.${parts[1].slice(0, 2)}`;
-      }
-
-      setInputValue(cleanFiatText);
+      setInputValue(rawText.replace(/\D/g, ""));
+      return;
     }
+
+    if (!fiatRate) return;
+    let cleanFiatText = rawText.replace(/[^0-9.]/g, "");
+    const parts = cleanFiatText.split(".");
+
+    if (parts.length > 2) {
+      cleanFiatText = `${parts[0]}.${parts.slice(1).join("")}`;
+    }
+
+    if (parts.length >= 2) {
+      cleanFiatText = `${parts[0]}.${parts[1].slice(0, 2)}`;
+    }
+
+    setInputValue(cleanFiatText);
   };
 
   const toggleIsSats = () => {

--- a/src/app/wallet/send/page.tsx
+++ b/src/app/wallet/send/page.tsx
@@ -16,7 +16,7 @@ import {
   useExecuteLnurlPay,
 } from "@/hooks/use-breez";
 import { useFiat } from "@/hooks/use-fiat";
-import { formatFiat } from "@/lib/wallet/format-fiat";
+import { formatFiat, SATS_PER_BTC } from "@/lib/wallet/format-fiat";
 import { useT } from "@/lib/i18n/hook";
 import type {
   PrepareSendResult,
@@ -44,9 +44,7 @@ export default function SendPage() {
   const isUnlocked = useWalletStore((s) => s.isUnlocked);
   const [step, setStep] = useState<SendStep>("input");
   const [destination, setDestination] = useState("");
-  const [rawSats, setRawSats] = useState<number>(0);
-  const [amountSatInput, setAmountSatInput] = useState("");
-  const [amountFiatInput, setAmountFiatInput] = useState("");
+  const [inputValue, setInputValue] = useState("");
   const [isSats, setIsSats] = useState(true);
   const [prepareResult, setPrepareResult] = useState<PrepareResult | null>(null,);
   const [error, setError] = useState("");
@@ -77,6 +75,19 @@ export default function SendPage() {
     }
   };
 
+  const parseSats = (value: string): number | undefined => {
+    if (isSats) {
+      const cleanSatsText = value.replace(/\D/g, "");
+      return Number.parseInt(cleanSatsText, 10) || 0;
+    } else {
+      if (!fiatRate) return undefined;
+      const cleanFiatText = value.replace(/[^0-9.]/g, "");
+      const fiat = Number.parseFloat(cleanFiatText) || 0;
+      return Math.round((fiat / fiatRate) * SATS_PER_BTC);
+    }
+  };
+
+
   const handleContinue = async () => {
     setError("");
     const dest = destination.trim();
@@ -92,7 +103,7 @@ export default function SendPage() {
         return;
       }
 
-      const amountSat = rawSats ?? undefined;
+      const amountSat = inputValue ? parseSats(inputValue) : undefined;
 
       let prep: PrepareResult;
       if (parsed.type === "lnurlPay" || parsed.type === "lightningAddress") {
@@ -167,65 +178,52 @@ export default function SendPage() {
     setStep("input");
     setError("");
     setDestination("");
-    setAmountSatInput("");
-    setAmountFiatInput("");
+    setInputValue("");
     setPrepareResult(null);
   };
 
-  useEffect(() => {
-    if (!fiatRate) return;
-
-    if (!rawSats || rawSats <= 0) {
-      setAmountSatInput("");
-      setAmountFiatInput("");
-      return;
-    }
-
-    if (isSats) {
-      setAmountSatInput(rawSats.toString());
-    } else {
-      const calculatedFiat = (rawSats / 100_000_000) * fiatRate;
-      setAmountFiatInput(`$${calculatedFiat.toFixed(2)}`);
-    }
-  }, [isSats]);
-
   const handleAmountInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!fiatRate) return;
+    const rawText = e.target.value;
 
     if (isSats) {
-      const cleanSats = e.target.value.replace(/[^0-9]/g, "");
-      setAmountSatInput(cleanSats);
-
-      const satsNumber = parseInt(cleanSats, 10) || 0;
-      setRawSats(satsNumber);
+      const cleanSatsText = rawText.replace(/\D/g, "");
+      setInputValue(cleanSatsText);
     } else {
-      let value = e.target.value.replace(/[^0-9.]/g, "");
+      let cleanFiatText = rawText.replace(/[^0-9.]/g, "");
+      const parts = cleanFiatText.split(".");
 
-      if (value === "") {
-        setAmountFiatInput("");
-        setRawSats(0);
-        return;
-      }
-
-      if (value.startsWith(".")) {
-        value = "0" + value
-      };
-
-      const parts = value.split(".");
       if (parts.length > 2) {
-        value = `${parts[0]}.${parts.slice(1).join("")}`;
+        cleanFiatText = `${parts[0]}.${parts.slice(1).join("")}`;
       }
 
       if (parts.length >= 2) {
-        value = `${parts[0]}.${parts[1].slice(0, 2)}`;
+        cleanFiatText = `${parts[0]}.${parts[1].slice(0, 2)}`;
       }
 
-      setAmountFiatInput(`$${value}`);
-
-      const numericFiat = parseFloat(value) || 0;
-      const calculatedSats = Math.round((numericFiat / fiatRate) * 100_000_000);
-      setRawSats(calculatedSats);
+      setInputValue(cleanFiatText);
     }
+  };
+
+  const toggleIsSats = () => {
+    setIsSats((prevIsSats) => {
+      const nextIsSats = !prevIsSats;
+      const rawSats = parseSats(inputValue);
+
+      if (!rawSats) {
+        setInputValue("");
+        return nextIsSats;
+      }
+
+      if (nextIsSats) {
+        setInputValue(rawSats.toString());
+      } else if (fiatRate) {
+        const fiat = (rawSats / SATS_PER_BTC) * fiatRate;
+        setInputValue(fiat.toFixed(2));
+      }
+
+      return nextIsSats;
+    });
   };
 
   if (!isUnlocked) return null;
@@ -276,24 +274,19 @@ export default function SendPage() {
               />
               <div className="flex flex-row">
                 <Input
-                  label={
-                    isSats
-                      ? t("send.amount.label")
-                      : t("send.amount.fiat", { currency: fiatCurrency.toLocaleLowerCase() })
-                  }
+                  label={isSats ? t("send.amount.label") : t("send.amount.fiat", { currency: fiatCurrency.toLocaleLowerCase() })}
                   placeholder={t("send.amount.placeholder")}
-                  value={isSats ? amountSatInput : amountFiatInput}
+                  value={inputValue}
                   onChange={(e) => {
                     handleAmountInput(e);
                   }}
-                  inputMode="numeric"
+                  inputMode={isSats ? "numeric" : "decimal"}
                   helperText={t("send.amount.helper")}
                 />
                 <button
                   className="px-2 h-16 flex items-end justify-center"
-                  onClick={() => {
-                    setIsSats(!isSats);
-                  }}
+                  onClick={toggleIsSats}
+                  type="button"
                 >
                   <ArrowDownUp />
                 </button>

--- a/src/app/wallet/send/page.tsx
+++ b/src/app/wallet/send/page.tsx
@@ -46,7 +46,7 @@ export default function SendPage() {
   const [destination, setDestination] = useState("");
   const [inputValue, setInputValue] = useState("");
   const [isSats, setIsSats] = useState(true);
-  const [prepareResult, setPrepareResult] = useState<PrepareResult | null>(null,);
+  const [prepareResult, setPrepareResult] = useState<PrepareResult | null>(null);
   const [error, setError] = useState("");
 
   const { data: balance } = useBalance(true);
@@ -228,6 +228,8 @@ export default function SendPage() {
 
   if (!isUnlocked) return null;
 
+  const isFiatRateAvailable: boolean = fiatRate !== undefined && fiatRate !== null && fiatCurrency !== undefined && fiatCurrency !== null;
+
   if (step === "input") {
     return (
       <div className="min-h-screen min-w-fit bg-gray-50 dark:bg-gray-900">
@@ -287,8 +289,9 @@ export default function SendPage() {
                   className="px-2 h-16 flex items-end justify-center"
                   onClick={toggleIsSats}
                   type="button"
+                  disabled={!isFiatRateAvailable}
                 >
-                  <ArrowDownUp />
+                  <ArrowDownUp opacity={!isFiatRateAvailable ? 0.5 : 1 }/>
                 </button>
               </div>
               <div className="grid grid-cols-1 gap-3">

--- a/src/app/wallet/settings/page.tsx
+++ b/src/app/wallet/settings/page.tsx
@@ -363,7 +363,7 @@ function DriveBackupSection() {
   );
 }
 
-function LanguagePickerSection() {
+export function LanguagePickerSection() {
   const { locale, setLocale } = useLocale();
   return (
     <select

--- a/src/app/wallet/settings/page.tsx
+++ b/src/app/wallet/settings/page.tsx
@@ -40,11 +40,11 @@ import {
   getLastSyncIso,
   getDriveEmail,
 } from "@/lib/backup/drive-client";
-import { useT, useLocale } from "@/lib/i18n/hook";
-import { LOCALES, LOCALE_LABELS, type Locale } from "@/lib/i18n/types";
+import { useT } from "@/lib/i18n/hook";
 import { useFormatRelativeTime } from "@/lib/wallet/relative-time";
 import type { SdkEvent } from "@/lib/lightning/sdk-events";
 import type { LightningAddressInfo } from "@breeztech/breez-sdk-spark";
+import { LanguagePickerSection } from "@/components/ui/language-picker";
 
 const USERNAME_RE = /^[a-z0-9._-]{1,32}$/;
 
@@ -360,23 +360,6 @@ function DriveBackupSection() {
         </div>
       </Modal>
     </div>
-  );
-}
-
-export function LanguagePickerSection() {
-  const { locale, setLocale } = useLocale();
-  return (
-    <select
-      value={locale}
-      onChange={(e) => setLocale(e.target.value as Locale)}
-      className="w-full px-3 py-2 rounded-lg border-2 border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm"
-    >
-      {LOCALES.map((code) => (
-        <option key={code} value={code}>
-          {LOCALE_LABELS[code]}
-        </option>
-      ))}
-    </select>
   );
 }
 

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Earth, Fingerprint } from "lucide-react";
@@ -11,8 +11,7 @@ import { Modal } from "@/components/ui/modal";
 import { MnemonicDisplay } from "@/components/wallet/mnemonic-display";
 import { APP_NAME } from "@/lib/config";
 import { useWalletStore } from "@/store/wallet-store";
-import { useLocale, useT } from "@/lib/i18n/hook";
-import { LOCALES, LOCALE_LABELS } from "@/lib/i18n/types";
+import { useT } from "@/lib/i18n/hook";
 import {
   isPasskeySupported,
   registerPasskey,
@@ -20,10 +19,13 @@ import {
   seedToMnemonic,
 } from "@/lib/auth/passkey";
 import { mnemonicToWords } from "@/lib/bitcoin/mnemonic";
+import { LanguagePickerSection } from "../wallet/settings/page";
 
 export default function WelcomePage() {
   const t = useT();
   const router = useRouter();
+  const containerRef = useRef<HTMLDivElement>(null);
+
   const hasVault = useWalletStore((s) => s.hasVault);
   const authMode = useWalletStore((s) => s.authMode);
   const isUnlocked = useWalletStore((s) => s.isUnlocked);
@@ -40,7 +42,6 @@ export default function WelcomePage() {
   const [showForget, setShowForget] = useState(false);
   const [forgetConfirm, setForgetConfirm] = useState("");
   const [forgetting, setForgetting] = useState(false);
-  const [showLanguageSelector, setShowLanguageSelector] = useState(false);
 
   const [passkeyAvailable, setPasskeyAvailable] = useState(false);
   const [passkeyMode, setPasskeyMode] = useState(false);
@@ -71,16 +72,6 @@ export default function WelcomePage() {
     // already routes; including it here would race the close with a re-nav.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isBootstrapped, isUnlocked, router]);
-
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        setShowLanguageSelector(false);
-      }
-    }
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [])
 
   const handleCreateWallet = () => {
     setCreatingWallet(true);
@@ -158,6 +149,18 @@ export default function WelcomePage() {
   const showPasskeyUnlock = hasVault && authMode === "passkey";
   const showPasswordUnlock = hasVault && authMode !== "passkey";
 
+  const handleClick = () => {
+  const selectElement = containerRef.current?.querySelector<HTMLSelectElement>("select");
+
+  if (selectElement) {
+    if ("showPicker" in selectElement) {
+      selectElement.showPicker();
+    } else {
+      return null;
+    }
+  }
+};
+
   return (
     <div className="min-h-screen min-w-fit flex flex-col justify-between px-6 py-6 sm:py-10">
       <div className="flex flex-col items-center pb-6 pt-10 sm:flex-1 sm:justify-end sm:pb-20 sm:pt-0">
@@ -171,11 +174,23 @@ export default function WelcomePage() {
           {t("welcome.tagline")}
         </p>
       </div>
-      
-      <button type="button" className="fixed top-6 right-6" onClick={() => setShowLanguageSelector(showLanguageSelector => !showLanguageSelector)}>
-        <Earth />
-      </button>
-      {showLanguageSelector && <LanguageSelectorPopover />}
+
+      <div className="fixed top-6 right-6">
+        <button
+          type="button"
+          onClick={handleClick}
+          className="p-2 z-50 rounded-lg hover:bg-neutral-800/50 transition-colors cursor-pointer text-gray-300 hover:text-white"
+        >
+          <Earth className="w-6 h-6" />
+        </button>
+
+        <div
+          ref={containerRef}
+          className="absolute right-6 top-9 mt-1 opacity-0 pointer-events-none [&>select]:w-auto"
+        >
+          <LanguagePickerSection />
+        </div>
+      </div>
 
       <div className="flex-1 flex flex-col justify-center space-y-4 max-w-md mx-auto w-full px-6">
         {showPasswordUnlock && (
@@ -455,20 +470,4 @@ export default function WelcomePage() {
       </Modal>
     </div>
   );
-}
-
-function LanguageSelectorPopover() {
-  const { locale, setLocale } = useLocale();
-  return (
-    <Card  className="flex flex-col items-start fixed top-12 right-12 pl-4 pr-4 pb-1 pt-1 space-y-1">
-      {LOCALES.map((code) => (
-        <button
-          type="button"
-          className={`cursor-pointer hover:text-blue-600 ${locale === code ? "text-blue-600" : ""}`}
-          key={code}
-          onClick={() => setLocale(code)}>{LOCALE_LABELS[code]}
-        </button>
-      ))}
-    </Card>
-  )
 }

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -175,7 +175,7 @@ export default function WelcomePage() {
         </p>
       </div>
 
-      <div className="fixed top-6 right-6">
+      <div className="fixed top-6 right-6 h-auto w-auto">
         <button
           type="button"
           onClick={handleClick}
@@ -186,7 +186,7 @@ export default function WelcomePage() {
 
         <div
           ref={containerRef}
-          className="absolute right-6 top-9 mt-1 opacity-0 pointer-events-none [&>select]:w-auto"
+          className="absolute right-6 top-16 mt-1 opacity-0 pointer-events-none [&>select]:w-auto"
         >
           <LanguagePickerSection />
         </div>

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { Fingerprint } from "lucide-react";
+import { Earth, Fingerprint } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -11,7 +11,8 @@ import { Modal } from "@/components/ui/modal";
 import { MnemonicDisplay } from "@/components/wallet/mnemonic-display";
 import { APP_NAME } from "@/lib/config";
 import { useWalletStore } from "@/store/wallet-store";
-import { useT } from "@/lib/i18n/hook";
+import { useLocale, useT } from "@/lib/i18n/hook";
+import { LOCALES, LOCALE_LABELS } from "@/lib/i18n/types";
 import {
   isPasskeySupported,
   registerPasskey,
@@ -39,6 +40,7 @@ export default function WelcomePage() {
   const [showForget, setShowForget] = useState(false);
   const [forgetConfirm, setForgetConfirm] = useState("");
   const [forgetting, setForgetting] = useState(false);
+  const [showLanguageSelector, setShowLanguageSelector] = useState(false);
 
   const [passkeyAvailable, setPasskeyAvailable] = useState(false);
   const [passkeyMode, setPasskeyMode] = useState(false);
@@ -69,6 +71,16 @@ export default function WelcomePage() {
     // already routes; including it here would race the close with a re-nav.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isBootstrapped, isUnlocked, router]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setShowLanguageSelector(false);
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [])
 
   const handleCreateWallet = () => {
     setCreatingWallet(true);
@@ -148,7 +160,7 @@ export default function WelcomePage() {
 
   return (
     <div className="min-h-screen min-w-fit flex flex-col justify-between px-6 py-6 sm:py-10">
-      <div className="flex flex-col items-center pb-6 sm:flex-1 sm:justify-end sm:pb-20">
+      <div className="flex flex-col items-center pb-6 pt-10 sm:flex-1 sm:justify-end sm:pb-20 sm:pt-0">
         <div className="w-16 h-16 sm:w-24 sm:h-24 bg-gradient-to-br from-blue-400 to-blue-600 rounded-2xl flex items-center justify-center shadow-xl mb-4 sm:mb-8">
           <span className="text-3xl sm:text-5xl font-bold text-white">₿</span>
         </div>
@@ -159,6 +171,11 @@ export default function WelcomePage() {
           {t("welcome.tagline")}
         </p>
       </div>
+      
+      <button type="button" className="fixed top-6 right-6" onClick={() => setShowLanguageSelector(showLanguageSelector => !showLanguageSelector)}>
+        <Earth />
+      </button>
+      {showLanguageSelector && <LanguageSelectorPopover />}
 
       <div className="flex-1 flex flex-col justify-center space-y-4 max-w-md mx-auto w-full px-6">
         {showPasswordUnlock && (
@@ -438,4 +455,20 @@ export default function WelcomePage() {
       </Modal>
     </div>
   );
+}
+
+function LanguageSelectorPopover() {
+  const { locale, setLocale } = useLocale();
+  return (
+    <Card  className="flex flex-col items-start fixed top-12 right-12 pl-4 pr-4 pb-1 pt-1 space-y-1">
+      {LOCALES.map((code) => (
+        <button
+          type="button"
+          className={`cursor-pointer hover:text-blue-600 ${locale === code ? "text-blue-600" : ""}`}
+          key={code}
+          onClick={() => setLocale(code)}>{LOCALE_LABELS[code]}
+        </button>
+      ))}
+    </Card>
+  )
 }

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -19,7 +19,7 @@ import {
   seedToMnemonic,
 } from "@/lib/auth/passkey";
 import { mnemonicToWords } from "@/lib/bitcoin/mnemonic";
-import { LanguagePickerSection } from "../wallet/settings/page";
+import { LanguagePickerSection } from "@/components/ui/language-picker";
 
 export default function WelcomePage() {
   const t = useT();

--- a/src/components/ui/language-picker.tsx
+++ b/src/components/ui/language-picker.tsx
@@ -1,0 +1,19 @@
+import { useLocale } from "@/lib/i18n/hook";
+import { Locale, LOCALE_LABELS, LOCALES } from "@/lib/i18n/types";
+
+export function LanguagePickerSection() {
+  const { locale, setLocale } = useLocale();
+  return (
+    <select
+      value={locale}
+      onChange={(e) => setLocale(e.target.value as Locale)}
+      className="w-full px-3 py-2 rounded-lg border-2 border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm"
+    >
+      {LOCALES.map((code) => (
+        <option key={code} value={code}>
+          {LOCALE_LABELS[code]}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/lib/wallet/format-fiat.ts
+++ b/src/lib/wallet/format-fiat.ts
@@ -1,4 +1,4 @@
-const SATS_PER_BTC = 100_000_000;
+export const SATS_PER_BTC = 100_000_000;
 
 // Format a sat amount as fiat using the given rate (price of 1 BTC in fiat).
 // Falls back to a plain numeric string with the currency code if Intl can't


### PR DESCRIPTION
### 📋 Context
<p>Currently, they are only available in English on the pre-login screen.  </p>
<p> As a user, I want to enter the amount to send in fiat currency (like USD) instead of Sats, so that I can easily understand how much money I am sending without doing manual math.</p>

### 🛠️ What has been done
- Add language selector on the Welcome page
- Implement support for fiat denominations on the Send screen

### 📦 Some considerations
<p>Currently, we only support English and Spanish.</p>

### 📷 Screenshots / GIFs 
<!-- Drag and drop your before/after images here -->
<img width="1800" height="1010" alt="Screenshot 2026-07-26 at 11 47 54 AM" src="https://github.com/user-attachments/assets/3a49bc2f-58a4-42d0-977e-4dbb43800da2" />
<img width="619" height="450" alt="Screenshot 2026-07-26 at 11 48 24 AM" src="https://github.com/user-attachments/assets/02c1aeec-73b4-49a9-b5bd-d8a7bff08c82" />

### 🎟️ JIRA Tickets
[ENG-368](https://b4os.atlassian.net/browse/ENG-368?atlOrigin=eyJpIjoiMzU4YjUzNzIyYTYwNDY2M2FiOTgxM2U0NjBlNGM2YzEiLCJwIjoiaiJ9)
[ENG-369](https://b4os.atlassian.net/browse/ENG-369?atlOrigin=eyJpIjoiMzcyN2MxOGI0ZGZhNDFiODg3M2Y3NWJmYjNhZTE0ZGMiLCJwIjoiaiJ9)


[ENG-368]: https://b4os.atlassian.net/browse/ENG-368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-369]: https://b4os.atlassian.net/browse/ENG-369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ