### PR TITLE
fix(ios): fix language selector layout on Safari

### DIFF
--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -148,19 +148,7 @@ export default function WelcomePage() {
 
   const showPasskeyUnlock = hasVault && authMode === "passkey";
   const showPasswordUnlock = hasVault && authMode !== "passkey";
-
-  const handleClick = () => {
-  const selectElement = containerRef.current?.querySelector<HTMLSelectElement>("select");
-
-  if (selectElement) {
-    if ("showPicker" in selectElement) {
-      selectElement.showPicker();
-    } else {
-      return null;
-    }
-  }
-};
-
+  
   return (
     <div className="min-h-screen min-w-fit flex flex-col justify-between px-6 py-6 sm:py-10">
       <div className="flex flex-col items-center pb-6 pt-10 sm:flex-1 sm:justify-end sm:pb-20 sm:pt-0">
@@ -175,19 +163,10 @@ export default function WelcomePage() {
         </p>
       </div>
 
-      <div className="fixed top-6 right-6 h-auto w-auto">
-        <button
-          type="button"
-          onClick={handleClick}
-          className="p-2 z-50 rounded-lg hover:bg-neutral-800/50 transition-colors cursor-pointer text-gray-300 hover:text-white"
-        >
-          <Earth className="w-6 h-6" />
-        </button>
+      <div className="fixed top-6 right-6 h-10 w-10 flex items-center justify-center rounded-lg hover:bg-neutral-800/50 transition-colors text-gray-300 hover:text-white">
+        <Earth className="w-6 h-6 pointer-events-none" />
 
-        <div
-          ref={containerRef}
-          className="absolute right-6 top-16 mt-1 opacity-0 pointer-events-none [&>select]:w-auto"
-        >
+        <div className="absolute inset-0 opacity-0 cursor-pointer [&>select]:w-full [&>select]:h-full [&>select]:cursor-pointer">
           <LanguagePickerSection />
         </div>
       </div>


### PR DESCRIPTION
### 📋 Context
<p>The language selector layout is broken on Safari, and the dropdown/picker cannot be opened.</p>

### 🛠️ What has been done
<p>Simplified the UI implementation by placing the selector element directly behind the icon.</p>

### 📦 Some considerations
<p></p>

### 📷 Screenshots / GIFs 
<!-- Drag and drop your before/after images here -->
<img width="1800" height="1011" alt="Screenshot 2026-07-28 at 4 56 22 PM" src="https://github.com/user-attachments/assets/aaf72405-ba15-42ed-87e7-e4bdd41a90f6" />
<img width="952" height="934" alt="Screenshot 2026-07-28 at 4 57 09 PM" src="https://github.com/user-attachments/assets/966ce85d-f1a1-4503-92ca-a07f981f37c8" />


### 🎟️ JIRA Tickets
<!-- Paste the Jira link or ticket ID below. -->
